### PR TITLE
correct event table for sandybridge-ep

### DIFF
--- a/static/generate_results.c
+++ b/static/generate_results.c
@@ -528,7 +528,7 @@ static int set_generic_modelname(int vendor, int family, int model) {
 		     break;
             case 45: /* Sandybridge EP (Romley) */
                      strcpy(cpuinfo.generic_modelname,"sandybridge-ep");
-                     event_table=&wsm_event_table;
+                     event_table=&snb_event_table;
                      break;
 
             case 58: /* Ivy Bridge */


### PR DESCRIPTION
The table for sandybridge-ep architecture was wsm_event_table instead of snb_event_table